### PR TITLE
url: remove apa6 style "retrieved from"

### DIFF
--- a/APASeventhEdition.xsl
+++ b/APASeventhEdition.xsl
@@ -448,8 +448,8 @@
         <xsl:with-param name="LCID" select="$LCID"/>
       </xsl:call-template>
     </xsl:variable>
-    <xsl:value-of select="/*/b:Locals/b:Local[@LCID=$_LCID]/b:Strings/b:RetrievedFromCap"/>-->
-    <xsl:text>Retrieved %1, from %2</xsl:text>
+    <xsl:value-of select="/*/b:Locals/b:Local[@LCID=$_LCID]/b:Strings/b:RetrievedFromCap"/>
+    <xsl:text>Retrieved %1, from %2</xsl:text>-->
   </xsl:template>
 
   
@@ -460,8 +460,8 @@
         <xsl:with-param name="LCID" select="$LCID"/>
       </xsl:call-template>
     </xsl:variable>
-    <xsl:value-of select="/*/b:Locals/b:Local[@LCID=$_LCID]/b:Strings/b:RetrievedCap"/>-->
-    <xsl:text>Retrieved %1.</xsl:text>
+    <xsl:value-of select="/*/b:Locals/b:Local[@LCID=$_LCID]/b:Strings/b:RetrievedCap"/>
+    <xsl:text>Retrieved %1.</xsl:text>-->
   </xsl:template>
 
   
@@ -472,8 +472,8 @@
         <xsl:with-param name="LCID" select="$LCID"/>
       </xsl:call-template>
     </xsl:variable>
-    <xsl:value-of select="/*/b:Locals/b:Local[@LCID=$_LCID]/b:Strings/b:FromCap"/>-->
-    <xsl:text>%1</xsl:text>
+    <xsl:value-of select="/*/b:Locals/b:Local[@LCID=$_LCID]/b:Strings/b:FromCap"/>
+    <xsl:text>%1</xsl:text>-->
   </xsl:template>
 
   


### PR DESCRIPTION
Omit the words “Retrieved from” tag. APA7 does not use that anymore