### PR TITLE
Fixed: For website sources, before the full URL, a colon was showing instead of a period

### DIFF
--- a/APASeventhEdition.xsl
+++ b/APASeventhEdition.xsl
@@ -7098,7 +7098,8 @@
       </xsl:if>
 
       <xsl:if test="string-length(b:InternetSiteTitle)>0 and string-length(b:URL)>0">
-        <xsl:call-template name="templ_prop_EnumSeparator"/>
+        <xsl:call-template name="templ_prop_Dot"/>
+        <xsl:call-template name="templ_prop_Space"/>
       </xsl:if>
 
       <xsl:if test="string-length(b:URL)>0">


### PR DESCRIPTION
Fixed colon (:) showing after website title for website sources instead of a period.

Now shows correctly as:
(...) Website Title. URL

Issue #11 