### PR TITLE
Make DOI links hyperlinks in html word output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*[eE]ztaban*

--- a/APASeventhEdition.sh
+++ b/APASeventhEdition.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Define the source URL for the file
+SOURCE_URL="https://raw.githubusercontent.com/briankavanaugh/APA-7th-Edition/main/APASeventhEdition.xsl"
+
+# Get the current username
+USERNAME=$(whoami)
+
+# Define the destination paths
+DESTINATION_PATH_1="/Applications/Microsoft Word.app/Contents/Resources/Style/APASeventhEdition.xsl"
+DESTINATION_PATH_2="/Users/$USERNAME/Library/Containers/com.microsoft.Word/Data/Library/Application Support/Microsoft/Office/Style/APASeventhEdition.xsl"
+
+# Download the file and place it in the first destination
+sudo curl "$SOURCE_URL" -o "$DESTINATION_PATH_1"
+
+# Check if the file was successfully downloaded
+if [ -e "$DESTINATION_PATH_1" ]; then
+    # If successful, also copy it to the second destination
+    sudo cp "$DESTINATION_PATH_1" "$DESTINATION_PATH_2"
+    echo "File placed in both locations successfully."
+else
+    echo "Failed to download the file."
+fi

--- a/APASeventhEdition.xsl
+++ b/APASeventhEdition.xsl
@@ -5600,11 +5600,6 @@
 
                 <xsl:choose>
                   <xsl:when test="string-length($doi)>0">
-                  <!--TEST DOI HYPERLINK-->
-                    <!--
-                    <xsl:value-of select="$doiPrefix"/>
-                    <xsl:value-of select="$doi"/> 
-                    -->
                       <a href="{$doiPrefix}{$doi}" target="_blank">
                         <xsl:value-of select="concat($doiPrefix, $doi)" />
                       </a>

--- a/APASeventhEdition.xsl
+++ b/APASeventhEdition.xsl
@@ -5600,8 +5600,14 @@
 
                 <xsl:choose>
                   <xsl:when test="string-length($doi)>0">
+                  <!--TEST DOI HYPERLINK-->
+                    <!--
                     <xsl:value-of select="$doiPrefix"/>
-                    <xsl:value-of select="$doi"/>
+                    <xsl:value-of select="$doi"/> 
+                    -->
+                      <a href="{$doiPrefix}{$doi}" target="_blank">
+                        <xsl:value-of select="concat($doiPrefix, $doi)" />
+                      </a>
                   </xsl:when>
                   <xsl:when test="string-length($tempRDAFU)>0">
                     <xsl:value-of select="$tempRDAFU"/>

--- a/README.md
+++ b/README.md
@@ -25,11 +25,30 @@ curl https://raw.githubusercontent.com/briankavanaugh/APA-7th-Edition/main/APASe
 
 ### MacOS
 
+#### Manual method
 1. Exit Word
-1. Using Finder, copy the file APASeventhEdition.xsl to *two* locations:
+2. Using Finder, copy the file APASeventhEdition.xsl to *two* locations:
     1. HD/Applications/Microsoft Word.app/Contents/Resources/Style/ (note that you will have to right-click and "View Contents" on the app icon at HD/Applications/Microsoft Word.app/)
-    1. HD/Users/\<your_user_name>/Library/Containers/com.microsoft.Word/Data/Library/Application Support/Microsoft/Office/Style/
-1. Restart Word and from the References tab in Word, you should be able to choose APA7. 
+    2. HD/Users/\<your_user_name>/Library/Containers/com.microsoft.Word/Data/Library/Application Support/Microsoft/Office/Style/
+2. Restart Word and from the References tab in Word, you should be able to choose APA7. 
+
+#### Shell script method / terminal method
+* __The file asks for elevated priveliges using `sudo`. Only run files you trust and understand the contents of.__
+1. Exit word and ensure it is closed before proceeding
+2. Copy the APASeventhEdition.sh file to a local folder
+3. Open the terminal (Search "Terminal through spotlight)
+4. Navigate to the folder containing the shell script
+    1. `cd /path/to/your/file`
+5. Run the script
+    1. `bash APASeventhEdition.sh`
+    2. Enter password when prompted. The terminal stay blank while password is entered. Once entered, press enter
+    3. The files should be placed in their corresponding folders
+
+Notes:  
+* The bash file will use the `curl` command to retrieve the file from github at the specified link and place it in the first of the specified folders above.
+* It will then check if the file was placed in the folder successfully, and then copy the file from the first folder to the next.
+* I do not have a Mac to test this on. The script was run successfully on a Mac with Office installed.
+
 
 ## Disclaimer
 


### PR DESCRIPTION
- This pull request addresses issue #8 
- I have modified the concatenation of doi-prefix and doi link, so the resulting output is a hyperlink
- I tested this with an exam project, which had to adhere to APA7 guidelines and had DOI links
- Version of Word: Version 2310 (Build 16924.20180)