### PR TITLE
Fix: LaunchDaemon replaces stylesheet on every reboot for mac. Related to #23

### DIFF
--- a/APASeventhEdition.sh
+++ b/APASeventhEdition.sh
@@ -1,26 +1,89 @@
 #!/bin/bash
 
-# Define the source URL for the file
+# Constants
 SOURCE_URL="https://raw.githubusercontent.com/briankavanaugh/APA-7th-Edition/main/APASeventhEdition.xsl"
+LOCAL_DIR="/Library/Application Support/APAStyleTool"
+LOCAL_FILE="$LOCAL_DIR/APASeventhEdition.xsl"
+PLIST_FILE="/Library/LaunchDaemons/com.apastyle.copy.plist"
 
-# Get the current username
-USERNAME=$(whoami)
+# Determine username and home directory
+USERNAME=$(stat -f "%Su" /dev/console)
+USER_HOME=$(dscl . -read /Users/$USERNAME NFSHomeDirectory | awk '{print $2}')
 
-# Define the destination paths
+# Target paths
 DESTINATION_PATH_1="/Applications/Microsoft Word.app/Contents/Resources/Style/APASeventhEdition.xsl"
-DESTINATION_PATH_2="/Users/$USERNAME/Library/Containers/com.microsoft.Word/Data/Library/Application Support/Microsoft/Office/Style/APASeventhEdition.xsl"
+DESTINATION_PATH_2="$USER_HOME/Library/Containers/com.microsoft.Word/Data/Library/Application Support/Microsoft/Office/Style/APASeventhEdition.xsl"
 
-# Download the file and place it in the first destination
-echo "Path 1:$DESTINATION_PATH_1"
-echo "Path 2:$DESTINATION_PATH_2"
+echo "Downloading and installing APA style file..."
 
-sudo curl "$SOURCE_URL" -o "$DESTINATION_PATH_1"
+# Create local folder and download the file
+sudo mkdir -p "$LOCAL_DIR"
+sudo curl -fsSL "$SOURCE_URL" -o "$LOCAL_FILE"
 
-# Check if the file was successfully downloaded
-if [ -e "$DESTINATION_PATH_1" ]; then
-    # If successful, also copy it to the second destination
-    sudo mkdir -p "$DESTINATION_PATH_2" && sudo cp "$DESTINATION_PATH_1" "$DESTINATION_PATH_2"
-    echo "File placed in both locations successfully."
+# Copy immediately to both destinations
+sudo cp "$LOCAL_FILE" "$DESTINATION_PATH_1"
+sudo mkdir -p "$(dirname "$DESTINATION_PATH_2")"
+sudo cp "$LOCAL_FILE" "$DESTINATION_PATH_2"
+echo "Initial file copy completed."
+
+# Check for --persist flag
+if [[ "$1" == "--persist" ]]; then
+    echo "Setting up LaunchDaemon for persistence..."
+
+    # Write LaunchDaemon plist with detailed comments
+    sudo tee "$PLIST_FILE" > /dev/null <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+ "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+
+    <!-- Unique identifier for the daemon -->
+    <key>Label</key>
+    <string>com.apastyle.copy</string>
+
+    <!-- The command to run: copy the local file to both Word destinations -->
+    <key>ProgramArguments</key>
+    <array>
+        <!-- Execute the following shell command -->
+        <string>/bin/bash</string>
+        <string>-c</string>
+        <!-- Actual copy command: from local file to system and user template paths -->
+        <string>
+            cp "$LOCAL_FILE" "$DESTINATION_PATH_1" &&
+            mkdir -p "$(dirname "$DESTINATION_PATH_2")" &&
+            cp "$LOCAL_FILE" "$DESTINATION_PATH_2"
+        </string>
+    </array>
+
+    <!-- Run this job when the system loads the daemon (i.e. at boot) -->
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- Optional: path for stdout logging -->
+    <key>StandardOutPath</key>
+    <string>/var/log/apastylecopy.log</string>
+
+    <!-- Optional: path for stderr logging -->
+    <key>StandardErrorPath</key>
+    <string>/var/log/apastylecopy.log</string>
+
+</dict>
+</plist>
+EOF
+
+    # Set ownership and permissions — required for launchd to accept it
+    sudo chown root:wheel "$PLIST_FILE"
+    sudo chmod 644 "$PLIST_FILE"
+
+    # Load and enable the daemon
+    sudo launchctl load -w "$PLIST_FILE"
+
+    echo "LaunchDaemon installed and will run on each boot."
+    echo "To remove, run: sudo launchctl unload -w $PLIST_FILE && sudo rm $PLIST_FILE"
+    echo "To disable, run: sudo launchctl unload -w $PLIST_FILE"
+    echo "Logs can be found at /var/log/apastylecopy.log"
+    echo "To view logs, run: tail -f /var/log/apastylecopy.log"
 else
-    echo "Failed to download the file."
+    echo "No persistence flag given. Skipping LaunchDaemon setup."
 fi

--- a/README.md
+++ b/README.md
@@ -9,35 +9,39 @@ Until (unless) Microsoft gets around to adding a template for the latest version
 ### Windows
 
 #### Manual Method
+
 1. Exit Word
-2. Using Windows Explorer, copy the file APASeventhEdition.xsl to C:\Users\<your_user_name>\AppData\Roaming\Microsoft\Bibliography\Style 
-3. Restart Word and from the References tab in Word, you should be able to choose APA7. 
+2. Using Windows Explorer, copy the file APASeventhEdition.xsl to C:\Users\<your_user_name>\AppData\Roaming\Microsoft\Bibliography\Style
+3. Restart Word and from the References tab in Word, you should be able to choose APA7.
 
 #### Bat file method / Cmd method
+
 1. Exit word
 2. Copy the APASeventhEdition.bat file and allow it to run.
-3. Restart Word and from the References tab in Word, you should be able to choose APA7. 
+3. Restart Word and from the References tab in Word, you should be able to choose APA7.
 
 Note: The bat file simply runs the following line:
-```
+
+```bash
 curl https://raw.githubusercontent.com/briankavanaugh/APA-7th-Edition/main/APASeventhEdition.xsl -o "%appdata%\Microsoft\Bibliography\Style\APASeventhEdition.xsl"
 ```
-
-
 
 ### MacOS
 
 #### Manual method
+
 1. Exit Word
 2. Using Finder, copy the file APASeventhEdition.xsl to *two* locations:
     1. HD/Applications/Microsoft Word.app/Contents/Resources/Style/ (note that you will have to right-click and "View Contents" on the app icon at HD/Applications/Microsoft Word.app/)
     2. HD/Users/\<your_user_name>/Library/Containers/com.microsoft.Word/Data/Library/Application Support/Microsoft/Office/Style/
-2. Restart Word and from the References tab in Word, you should be able to choose APA7. 
+3. Restart Word and from the References tab in Word, you should be able to choose APA7.
 
 #### Shell script method / terminal method
-* __The file asks for elevated priveliges using `sudo`. Only run files you trust and understand the contents of.__
+
+* **The file asks for elevated priveliges using `sudo`. Only run files you trust and understand the contents of.**
+
 1. Exit word and ensure it is closed before proceeding
-2. Copy the APASeventhEdition.sh file to a local folder
+2. Copy the `APASeventhEdition.sh` file to a local folder
 3. Open the terminal (Search "Terminal through spotlight)
 4. Navigate to the folder containing the shell script
     1. `cd /path/to/your/file`
@@ -45,13 +49,16 @@ curl https://raw.githubusercontent.com/briankavanaugh/APA-7th-Edition/main/APASe
     1. `bash APASeventhEdition.sh`
     2. Enter password when prompted. The terminal stay blank while password is entered. Once entered, press enter
     3. The files should be placed in their corresponding folders
+    4. *Optionally:* run the script with the `--persist` flag to create a LaunchDaemon. The LaunchDaemon will copy the files into their respective folders at reboot to combat issue where Microsoft AutoUpdater removes the files: `bash APASeventhEdition.sh --persist`.
 
 Notes:  
-* The bash file will use the `curl` command to retrieve the file from github at the specified link and place it in the first of the specified folders above.
-* It will then check if the file was placed in the folder successfully, and then copy the file from the first folder to the next.
-* I do not have a Mac to test this on. The script was run successfully on a Mac with Office installed.
 
+* The bash file will use the `curl` command to retrieve the file from github at the specified link and place it in `/Library/Application Support/APAStyleTool`.
+* Then it will copy the stylesheet into the two specified folders.
+* If the `--persist` flag is used a LaunchDaemon is created. This will copy the file from the `/Library/Application Support/APAStyleTool` folder to the two Word-folders every time the computer is rebooted.
+* Be aware, that the LaunchDaemon is run at boot and has root privileges to avoid user interaction. **Always read the script before running it.**
+* I do not have a Mac to test this on. The script was run successfully on a Mac with Office installed.
 
 ## Disclaimer
 
-(same as Mike's) I am only providing this file and the necessary location for it for education purposes. If any installations of MS Office are corrupted as a result of using this file, I am not responsible to address or repair any issues. 
+(same as Mike's) I am only providing this file and the necessary location for it for education purposes. If any installations of MS Office are corrupted as a result of using this file, I am not responsible to address or repair any issues.


### PR DESCRIPTION
Enhanced macos shell script. 
Downloaded files are placed in local directory and copied into the word-directories.  
If --persist flag is used, a LaunchDaemon is created, which will copy the files from the local directory to the word-directories at every reboot.  
LaunchDaemon is used over LaunchAgent to do it at reboot, and not after logout/login. This is because programs have to be shit down for script to be successfull and that is not guaranteed to be the case after logout/login.
Fixes #23 .
