### PR TITLE
Feat: Add support for Medium field to Document from web site citation type

### DIFF
--- a/APASeventhEdition.xsl
+++ b/APASeventhEdition.xsl
@@ -1605,6 +1605,14 @@
     <xsl:value-of select="/*/b:Locals/b:Local[@LCID=$_LCID]/b:General/b:ListSeparator"/>
   </xsl:template>
 
+  <xsl:template name="formatMediumInBrackets">
+    <xsl:if test="string-length(b:Medium) > 0">
+      <xsl:call-template name="templ_prop_Space"/>
+      <xsl:call-template name="templ_prop_APA_SecondaryOpen"/>
+      <xsl:value-of select="b:Medium"/>
+      <xsl:call-template name="templ_prop_APA_SecondaryClose"/>
+    </xsl:if>
+  </xsl:template>
   
   <xsl:template name="templ_prop_Dot" >
     <xsl:param name="LCID" />
@@ -5014,15 +5022,17 @@
                             <xsl:value-of select="$enclosedDateDot"/>
                           </xsl:if>
 
-                          <xsl:if test="string-length($titleDot)>0">
+                          <xsl:if test="string-length(b:Title)>0">
                             <xsl:call-template name="templ_prop_Space"/>
                             <xsl:call-template name = "ApplyItalicTitleNS">
                               <xsl:with-param name = "data">
-                                <xsl:value-of select="$titleDot"/>
+                                <xsl:value-of select="b:Title"/>
                               </xsl:with-param>
                             </xsl:call-template>
-                          </xsl:if>
 
+                            <xsl:call-template name="formatMediumInBrackets"/>
+                            <xsl:call-template name="templ_prop_Dot"/>
+                          </xsl:if>
                           <xsl:if test="string-length($theEditorAndTranslatorDot)>0">
                             <xsl:call-template name="templ_prop_Space"/>
                             <xsl:value-of select="$theEditorAndTranslatorDot"/>


### PR DESCRIPTION
This pull request adds support for displaying the medium field (e.g., [Video]) for the "Document From Web site" citation type, following APA 7th Edition guidelines.
Of course, this can be useful not only for [Video].

**Example:**
<img width="696" height="432" alt="creating a citation in APA 7th with Medium field filled in" src="https://github.com/user-attachments/assets/4b5c5c5c-0b94-4311-bbb2-4327a6f478c7" />


**Was:**
<img width="806" height="71" alt="Denissov, N. (2025, March 3). _Traffic Light Circuit Demonstration With Yellow Blinking Mode_. YouTube. https://youtu.be/PPVuRpgtut8" src="https://github.com/user-attachments/assets/c815c900-ae0b-467c-9b77-0097c4a969e0" />

**Became:**

<img width="799" height="68" alt="Denissov, N. (2025, March 3). _Traffic Light Circuit Demonstration With Yellow Blinking Mode_ [Video]. YouTube. https://youtu.be/PPVuRpgtut8" src="https://github.com/user-attachments/assets/3e6e4197-55a0-48bf-8adc-c3036141e2a6" />